### PR TITLE
Fix semver expression

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "vinyl": "^0.2.3"
   },
   "peerDependencies": {
-    "metalsmith": "^0.10||^0.11|^1.0.0"
+    "metalsmith": "^0.10||^0.11||^1.0.0"
   },
   "devDependencies": {
     "chai": "^1.9.1",


### PR DESCRIPTION
Missing second pipe prevented support for metalsmith 1.x
